### PR TITLE
Help command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,6 +1,13 @@
 # RanvierMUD
 NodeJS based MUD engine with full localization support
 
+## Contributing to this fork
+This fork aims to eventually turn the lightweight MUD engine Ranvier, developed by shawncplus, into a full-fledged game. The setting is, currently, a post-apocalyptic steampunk port town. That is probably a cliche, but I don't care. Right now, the master branch is working and has a fair amount of new content and features. However, I have a better understanding of the codebase now so it is in flux.
+
+There is also a development branch where I am working on rewriting some of the features to submit to the upstream project. At some point, the dev branch will be updated to include a lot more content. For the time being, it's bare since I am rewriting some features I'd already added.
+
+Please submit any PRs that are related to making this into a game to this project, preferably the master branch. Please submit any features based on enhancing the MUD engine itself to the shawncplus project.
+
 ## Features
 * Full localization for any strings displayed to the player after they log in. This isn't a common feature in MUDs so I'll explain it. Player A and Player B log in, play the same game and see a different language. Same items, npcs, rooms, etc, different language.
 * Scripting support: It's in Javascript! No need for a shitty DSL. The codebase is javascript, the scripting is javascript.
@@ -24,6 +31,8 @@ NodeJS based MUD engine with full localization support
     cd ranviermud
     npm install
     sudo ./ranvier -v --save=10 --respawn=10
+
+Connect to the server using `telnet 23`
     
 
 ## Documentation

--- a/README.mkd
+++ b/README.mkd
@@ -1,13 +1,6 @@
 # RanvierMUD
 NodeJS based MUD engine with full localization support
 
-## Contributing to this fork
-This fork aims to eventually turn the lightweight MUD engine Ranvier, developed by shawncplus, into a full-fledged game. The setting is, currently, a post-apocalyptic steampunk port town. That is probably a cliche, but I don't care. Right now, the master branch is working and has a fair amount of new content and features. However, I have a better understanding of the codebase now so it is in flux.
-
-There is also a development branch where I am working on rewriting some of the features to submit to the upstream project. At some point, the dev branch will be updated to include a lot more content. For the time being, it's bare since I am rewriting some features I'd already added.
-
-Please submit any PRs that are related to making this into a game to this project, preferably the master branch. Please submit any features based on enhancing the MUD engine itself to the shawncplus project.
-
 ## Features
 * Full localization for any strings displayed to the player after they log in. This isn't a common feature in MUDs so I'll explain it. Player A and Player B log in, play the same game and see a different language. Same items, npcs, rooms, etc, different language.
 * Scripting support: It's in Javascript! No need for a shitty DSL. The codebase is javascript, the scripting is javascript.

--- a/commands/help.js
+++ b/commands/help.js
@@ -3,7 +3,7 @@ var l10n = require('../src/l10n')(l10n_file);
 exports.command = function(rooms, items, players, npcs, Commands) {
   return function(args, player) {
     if (!args) {
-      player.sayL10n(l10n, 'USING_HELP');
+      player.writeL10n(l10n, 'USING_HELP');
       return;
     }
 
@@ -13,11 +13,11 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     }
 
     if (commands[args]) {
-      player.sayL10n(l10n, args.toUpperCase());
+      player.writeL10n(l10n, args.toUpperCase());
       return;
     }
 
-    player.sayL10n(l10n, 'NOT_FOUND');
+    player.writeL10n(l10n, 'NOT_FOUND');
     return;
   };
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -2,8 +2,14 @@ var l10n_file = __dirname + '/../l10n/commands/help.yml';
 var l10n = require('../src/l10n')(l10n_file);
 exports.command = function(rooms, items, players, npcs, Commands) {
   return function(args, player) {
+
+    function commandNotFound() {
+      player.writeL10n(l10n, 'NOT_FOUND');
+      return;
+    }
+
     if (!args) {
-      player.writeL10n(l10n, 'USING_HELP');
+      player.writeL10n(l10n, 'HELP');
       return;
     }
 
@@ -13,11 +19,16 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     }
 
     if (commands[args]) {
-      player.writeL10n(l10n, args.toUpperCase());
-      return;
+      try {
+        player.writeL10n(l10n, args.toUpperCase());
+        return;
+      } catch (err) {
+   		player.writeL10n(l10n, 'NO_HELP_FILE');
+   		return;
+      }
     }
-
     player.writeL10n(l10n, 'NOT_FOUND');
     return;
+
   };
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -29,6 +29,5 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     }
     player.writeL10n(l10n, 'NOT_FOUND');
     return;
-
   };
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -3,13 +3,15 @@ var l10n = require('../src/l10n')(l10n_file);
 exports.command = function(rooms, items, players, npcs, Commands) {
   return function(args, player) {
 
-    function commandNotFound() {
-      player.writeL10n(l10n, 'NOT_FOUND');
-      return;
-    }
+    var hr = function() {
+      player.say("\n=======================");
+    };
+    
+    hr();
 
     if (!args) {
       player.writeL10n(l10n, 'HELP');
+      hr();
       return;
     }
 
@@ -21,13 +23,15 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     if (commands[args]) {
       try {
         player.writeL10n(l10n, args.toUpperCase());
-        return;
       } catch (err) {
-   		player.writeL10n(l10n, 'NO_HELP_FILE');
-   		return;
+        player.writeL10n(l10n, 'NO_HELP_FILE');
+      } finally {
+        hr();
+        return;
       }
     }
     player.writeL10n(l10n, 'NOT_FOUND');
+    hr();
     return;
   };
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -13,11 +13,11 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     }
 
     if (commands[args]) {
-      player.sayL10n(l10n, args.toUpperCase();
+      player.sayL10n(l10n, args.toUpperCase());
       return;
     }
 
     player.sayL10n(l10n, 'NOT_FOUND');
-
+    return;
   };
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,23 @@
+var l10n_file = __dirname + '/../l10n/commands/help.yml';
+var l10n = require('../src/l10n')(l10n_file);
+exports.command = function(rooms, items, players, npcs, Commands) {
+  return function(args, player) {
+    if (!args) {
+      player.sayL10n(l10n, 'USING_HELP');
+      return;
+    }
+
+    var commands = {};
+    for (var command in Commands.player_commands) {
+      commands[command] = true;
+    }
+
+    if (commands[args]) {
+      player.sayL10n(l10n, args.toUpperCase();
+      return;
+    }
+
+    player.sayL10n(l10n, 'NOT_FOUND');
+
+  };
+};

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -20,4 +20,23 @@ EQUIPMENT:
     en: "Usage: \n  equipment\n\nList all items that your character has equipped."
 KILL:
     en: "Usage: \n  kill (NPC name) \nor \n  kill 2.(NPC name) to attack the 2nd NPC of that same name \n\nThis will cause your character to attempt to kill a non-player character (NPC).\nSome NPCs are pacifists and cannot be targeted."
-
+REMOVE:
+    en: "Usage: \n  remove (item name) \nor \n  remove 2.(item name) to remove the 2nd item of that same name \n\nThis will remove an item that is equipped and place it in your inventory."
+WEAR:
+    en: "Usage: \n  wear (item name) \nor \n  wear 2.(item name) to wear the 2nd item of that same name \n\nThis will equip an item that is in your inventory, as long as it is wearable.\nFor weapons, use 'wield'."
+LOOK:
+    en: "Usage: \n  look\n\nThis will describe your character's current location.\n\nUsage: \n  look (thing)\nor\n  look 2.(thing) to look at the 2nd thing of the same name \n\nThis will describe a non-player character or item in the same room as you. It can also be used to look at items in your inventory."
+SAVE:
+    en: "Usage: \n  save\n\nThis will save your character's progress. \nUsing 'quit' will save and then close your connection."
+SKILLS:
+    en: "Usage: \n  skills\n\nThis lists all skills available to your character, including a description and the cooldown time, if applicable."
+TNL:
+    en: "Usage: \n  tnl\n\nThis displays a bar of the amount of experience needed to gain your next level."
+EXP:
+    en: "Usage: \n  tnl\n\nThis displays a bar of the amount of experience needed to gain your next level."
+WHERE:
+    en: "Usage \n  where\n\nThis displays the name of your current location."
+WHO:
+    en: "Usage \n  who\n\nThis displays the name of each player who is online."
+WIELD:
+    en: "Usage: \n  wield (weapon)\n\n"

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -1,6 +1,10 @@
 USING_HELP:
-    en: "Type #red['commands'] to see a list of possible commands. Type #red['help (command)'] to see more information about that command."
+    en: "Type 'commands' to see a list of possible commands. Type 'help (command)'' to see more information about that command."
 NOT_FOUND:
-    en: "That command was not found. Type #red['commands'] to see a list of possible commands."
+    en: "That command was not found. Type 'commands' to see a list of possible commands."
 DROP:
-	en: "#blue[Usage:] #red[drop (item name)] \n This will drop the item if it is found in your inventory. You cannot drop items that are currently being worn."
+    en: "Usage: \n  drop (item name)\nor \n  drop 2.(item name) to drop the 2nd item of that same name \n\nThis will drop the item if it is found in your inventory. \nYou cannot drop items that are currently being worn."
+GET:
+    en: "Usage: \n  get (item name) \nor \n  get 2.(item name) to get the 2nd item of that same name \n\nThis will place the item in your inventory if it is in the same room as you.\nYou cannot get items while in combat."
+QUIT:
+    en: "Usage: \n  quit\n\nThis saves and closes your connection to RanvierMUD.\nYou cannot quit while in combat."

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -1,0 +1,6 @@
+USING_HELP:
+    en: "Type #red['commands'] to see a list of possible commands. Type #red['help (command)'] to see more information about that command."
+NOT_FOUND:
+    en: "That command was not found. Type #red['commands'] to see a list of possible commands."
+DROP:
+	en: "#blue[Usage:] #red[drop (item name)] \n This will drop the item if it is found in your inventory. You cannot drop items that are currently being worn."

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -1,7 +1,9 @@
-USING_HELP:
+HELP:
     en: "Type 'commands' to see a list of possible commands. Type 'help (command)'' to see more information about that command."
 NOT_FOUND:
-    en: "That command was not found. Type 'commands' to see a list of possible commands."
+    en: "That command was not found in the helpfiles. \nType 'commands' to see a list of possible commands."
+NO_HELP_FILE:
+    en: "No helpfile was found for that command.\nPlease contact an admin."
 DROP:
     en: "Usage: \n  drop (item name)\nor \n  drop 2.(item name) to drop the 2nd item of that same name \n\nThis will drop the item if it is found in your inventory. \nYou cannot drop items that are currently being worn."
 GET:

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -10,3 +10,14 @@ GET:
     en: "Usage: \n  get (item name) \nor \n  get 2.(item name) to get the 2nd item of that same name \n\nThis will place the item in your inventory if it is in the same room as you.\nYou cannot get items while in combat."
 QUIT:
     en: "Usage: \n  quit\n\nThis saves and closes your connection to RanvierMUD.\nYou cannot quit while in combat."
+CHANNELS:
+    en: "Usage: \n  channels\n\nList all available channels and their description."
+INVENTORY:
+    en: "Usage: \n  inventory\n\nList all items in your character's inventory, including the amount of each item.\nThis does not show you the items your character has equipped."
+COMMANDS:
+    en: "Usage: \n  commands\n\nList all possible commands."
+EQUIPMENT:
+    en: "Usage: \n  equipment\n\nList all items that your character has equipped."
+KILL:
+    en: "Usage: \n  kill (NPC name) \nor \n  kill 2.(NPC name) to attack the 2nd NPC of that same name \n\nThis will cause your character to attempt to kill a non-player character (NPC).\nSome NPCs are pacifists and cannot be targeted."
+

--- a/l10n/commands/help.yml
+++ b/l10n/commands/help.yml
@@ -1,5 +1,5 @@
 HELP:
-    en: "Type 'commands' to see a list of possible commands. Type 'help (command)'' to see more information about that command."
+    en: "Type 'commands' to see a list of possible commands.\nType 'help (command)'' to see more information about that command."
 NOT_FOUND:
     en: "That command was not found in the helpfiles. \nType 'commands' to see a list of possible commands."
 NO_HELP_FILE:
@@ -25,7 +25,7 @@ REMOVE:
 WEAR:
     en: "Usage: \n  wear (item name) \nor \n  wear 2.(item name) to wear the 2nd item of that same name \n\nThis will equip an item that is in your inventory, as long as it is wearable.\nFor weapons, use 'wield'."
 LOOK:
-    en: "Usage: \n  look\n\nThis will describe your character's current location.\n\nUsage: \n  look (thing)\nor\n  look 2.(thing) to look at the 2nd thing of the same name \n\nThis will describe a non-player character or item in the same room as you. It can also be used to look at items in your inventory."
+    en: "Usage: \n  look\n\nThis will describe your character's current location.\n\nUsage: \n  look (thing)\nor\n  look 2.(thing) to look at the 2nd thing of the same name \n\nThis will describe a non-player character or item in the same room as you. \nIt can also be used to look at items in your inventory."
 SAVE:
     en: "Usage: \n  save\n\nThis will save your character's progress. \nUsing 'quit' will save and then close your connection."
 SKILLS:

--- a/src/command_util.js
+++ b/src/command_util.js
@@ -38,7 +38,7 @@ var CommandUtil = {
 	},
 
 	/**
-	 * Find an item in a room based on the syntax
+	 * Find an item in inventory based on the syntax
 	 *   things like: get 2.thing or look 6.thing or look thing
 	 * @param string lookString
 	 * @param object being This could be a player or NPC. Though most likely player


### PR DESCRIPTION
**New command:**

`help` 

Typing in just `help` or `help help` will tell you how help works.
Typing in any other command will explain how that command works.

There is also error handling in case someone adds a custom command without adding documentation, so that the server will not crash. There is a separate message if the argument typed by the player is not actually a command. I'd imagine this command is easily extensible to include strings beyond just the usual commands, but it'd be only a bit of work (in case MUD creators want to include help files on the game's lore, areas, a helpfile for newbs, etc.) -- this could be a future feature. Or something for MUD creators to add, so that this engine stays fairly lightweight.

Incidentally, this PR also fixes a typo in one of the comments in command_util.js
