### PR TITLE
Whisper

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,6 +1,13 @@
 # RanvierMUD
 NodeJS based MUD engine with full localization support
 
+## Contributing to this fork
+This fork aims to eventually turn the lightweight MUD engine Ranvier, developed by shawncplus, into a full-fledged game. The setting is, currently, a post-apocalyptic steampunk port town. That is probably a cliche, but I don't care. Right now, the master branch is working and has a fair amount of new content and features. However, I have a better understanding of the codebase now so it is in flux.
+
+There is also a development branch where I am working on rewriting some of the features to submit to the upstream project. At some point, the dev branch will be updated to include a lot more content. For the time being, it's bare since I am rewriting some features I'd already added.
+
+Please submit any PRs that are related to making this into a game to this project, preferably the master branch. Please submit any features based on enhancing the MUD engine itself to the shawncplus project.
+
 ## Features
 * Full localization for any strings displayed to the player after they log in. This isn't a common feature in MUDs so I'll explain it. Player A and Player B log in, play the same game and see a different language. Same items, npcs, rooms, etc, different language.
 * Scripting support: It's in Javascript! No need for a shitty DSL. The codebase is javascript, the scripting is javascript.
@@ -24,6 +31,8 @@ NodeJS based MUD engine with full localization support
     cd ranviermud
     npm install
     sudo ./ranvier -v --save=10 --respawn=10
+
+Connect to the server using `telnet 23`
     
 
 ## Documentation

--- a/README.mkd
+++ b/README.mkd
@@ -25,7 +25,7 @@ NodeJS based MUD engine with full localization support
     npm install
     sudo ./ranvier -v --save=10 --respawn=10
 
-Connect to the server using `telnet 23`
+Connect to the server using `telnet localhost 23`
     
 
 ## Documentation

--- a/README.mkd
+++ b/README.mkd
@@ -1,13 +1,6 @@
 # RanvierMUD
 NodeJS based MUD engine with full localization support
 
-## Contributing to this fork
-This fork aims to eventually turn the lightweight MUD engine Ranvier, developed by shawncplus, into a full-fledged game. The setting is, currently, a post-apocalyptic steampunk port town. That is probably a cliche, but I don't care. Right now, the master branch is working and has a fair amount of new content and features. However, I have a better understanding of the codebase now so it is in flux.
-
-There is also a development branch where I am working on rewriting some of the features to submit to the upstream project. At some point, the dev branch will be updated to include a lot more content. For the time being, it's bare since I am rewriting some features I'd already added.
-
-Please submit any PRs that are related to making this into a game to this project, preferably the master branch. Please submit any features based on enhancing the MUD engine itself to the shawncplus project.
-
 ## Features
 * Full localization for any strings displayed to the player after they log in. This isn't a common feature in MUDs so I'll explain it. Player A and Player B log in, play the same game and see a different language. Same items, npcs, rooms, etc, different language.
 * Scripting support: It's in Javascript! No need for a shitty DSL. The codebase is javascript, the scripting is javascript.

--- a/commands/whisper.js
+++ b/commands/whisper.js
@@ -6,23 +6,29 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     console.log(args);
     args = args.split(' ');
     console.log(args);
-    var target = args.shift();
-    var msg = args.join('');
+    var target = args.shift().toLowerCase();
+    var msg = args.join(' ');
+    var targetFound = true;
 
-    if (args.length > 1) {
+    if (args.length > 0) {
+      targetFound = false;
       player.sayL10n(l10n, 'YOU_WHISPER', target, msg);
       players.eachIf(function(p) {
         return otherPlayersInRoom(p);
       }, function(p) {
-        if (p.getName() == target)
+        if (p.getName().toLowerCase() == target) {
           p.sayL10n(l10n, 'THEY_WHISPER', player.getName(), msg);
-        else
+          targetFound = true;
+        } else
           p.sayL10n(l10n, 'OTHERS_WHISPER', player.getName(), target);
       });
-      return;
+      if (targetFound) return;
     }
 
+    if (!targetFound)
+      player.sayL10n(l10n, 'NO_TARGET_FOUND');
     player.sayL10n(l10n, 'NOTHING_SAID');
+
     return;
   }
 

--- a/commands/whisper.js
+++ b/commands/whisper.js
@@ -1,0 +1,32 @@
+var l10n_file = __dirname + '/../l10n/commands/whisper.yml';
+var l10n = require('../src/l10n')(l10n_file);
+var CommandUtil = require('../src/command_util').CommandUtil;
+exports.command = function(rooms, items, players, npcs, Commands) {
+  return function(args, player) {
+    console.log(args);
+    args = args.split(' ');
+    console.log(args);
+    if (args.length > 1) {
+      player.sayL10n(l10n, 'YOU_WHISPER', args[0], args[1]);
+      players.eachIf(function(p) {
+        return otherPlayersInRoom(p);
+      }, function(p) {
+        if (p.getName() == args[0])
+          p.sayL10n(l10n, 'THEY_WHISPER', player.getName(), args[1]);
+        else
+          p.sayL10n(l10n, 'OTHERS_WHISPER', player.getName(), args[0]);
+      });
+      return;
+    }
+
+    player.sayL10n(l10n, 'NOTHING_SAID');
+    return;
+  }
+
+  function otherPlayersInRoom(p) {
+    if (p)
+      return (p.getName() !== player.getName() && p.getLocation() === player.getLocation());
+  };
+
+
+};

--- a/commands/whisper.js
+++ b/commands/whisper.js
@@ -6,15 +6,18 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     console.log(args);
     args = args.split(' ');
     console.log(args);
+    var target = args.shift();
+    var msg = args.join('');
+
     if (args.length > 1) {
-      player.sayL10n(l10n, 'YOU_WHISPER', args[0], args[1]);
+      player.sayL10n(l10n, 'YOU_WHISPER', target, msg);
       players.eachIf(function(p) {
         return otherPlayersInRoom(p);
       }, function(p) {
-        if (p.getName() == args[0])
-          p.sayL10n(l10n, 'THEY_WHISPER', player.getName(), args[1]);
+        if (p.getName() == target)
+          p.sayL10n(l10n, 'THEY_WHISPER', player.getName(), msg);
         else
-          p.sayL10n(l10n, 'OTHERS_WHISPER', player.getName(), args[0]);
+          p.sayL10n(l10n, 'OTHERS_WHISPER', player.getName(), target);
       });
       return;
     }
@@ -27,6 +30,5 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     if (p)
       return (p.getName() !== player.getName() && p.getLocation() === player.getLocation());
   };
-
 
 };

--- a/commands/whisper.js
+++ b/commands/whisper.js
@@ -6,23 +6,25 @@ exports.command = function(rooms, items, players, npcs, Commands) {
     console.log(args);
     args = args.split(' ');
     console.log(args);
-    var target = args.shift().toLowerCase();
+    var target = args.shift();
     var msg = args.join(' ');
     var targetFound = true;
 
     if (args.length > 0) {
       targetFound = false;
-      player.sayL10n(l10n, 'YOU_WHISPER', target, msg);
       players.eachIf(function(p) {
         return otherPlayersInRoom(p);
       }, function(p) {
-        if (p.getName().toLowerCase() == target) {
+        if (p.getName().toLowerCase() == target.toLowerCase()) {
           p.sayL10n(l10n, 'THEY_WHISPER', player.getName(), msg);
           targetFound = true;
         } else
           p.sayL10n(l10n, 'OTHERS_WHISPER', player.getName(), target);
       });
-      if (targetFound) return;
+      if (targetFound) {
+        player.sayL10n(l10n, 'YOU_WHISPER', target, msg);
+        return;
+      }
     }
 
     if (!targetFound)

--- a/l10n/commands/whisper.yml
+++ b/l10n/commands/whisper.yml
@@ -5,4 +5,6 @@ THEY_WHISPER:
 NOTHING_SAID:
     en: 'Type "whisper (name) (message)" to whisper to another player in the room.'
 OTHERS_WHISPER:
-    en: '$[1] whispers something to $[2]'
+    en: '$[1] whispers something to $[2].'
+NO_TARGET_FOUND:
+    en: 'The player you are trying to whisper to is not here.'

--- a/l10n/commands/whisper.yml
+++ b/l10n/commands/whisper.yml
@@ -1,0 +1,8 @@
+YOU_WHISPER:
+    en: 'You whisper to $[1], "$[2]"'
+THEY_WHISPER:
+    en: '$[1] whispers to you, "$[2]"'
+NOTHING_SAID:
+    en: 'Type "whisper (name) (message)" to whisper to another player in the room.'
+OTHERS_WHISPER:
+    en: '$[1] whispers something to $[2]'


### PR DESCRIPTION
This feature allows a player to type `whisper (name) (message)` and whisper a message only to other players. Third parties in the same room can see that the players are whispering to each other, but not what is said. Misuse of the command results in the proper and helpful error messages being displayed to the player.