### PR TITLE
Allow multiplay

### DIFF
--- a/bundles/core-input-events/input-events/choose-character.js
+++ b/bundles/core-input-events/input-events/choose-character.js
@@ -40,7 +40,10 @@ module.exports = (srcPath) => {
       if (canAddCharacter) {
         options.push({
           display: 'Create New Character',
-          onSelect: () => socket.emit('create-player', socket, { account }),
+          onSelect: () => { 
+            handleMultiplaying();
+            socket.emit('create-player', socket, { account })
+          },
         });
       }
 
@@ -71,7 +74,7 @@ module.exports = (srcPath) => {
           for (const character of account.characters) {
             kickIfAccountLoggedIn(character);
           }
-        } else {
+        } else if (selectedChar) {
           util.log("Multiplaying is allowed...");
           replaceIfCharLoggedIn(selectedChar);
         }

--- a/bundles/core-input-events/input-events/choose-character.js
+++ b/bundles/core-input-events/input-events/choose-character.js
@@ -73,7 +73,7 @@ module.exports = (srcPath) => {
           }
         } else {
           util.log("Multiplaying is allowed...");
-          replaceIfCharacterLoggedIn(selectedChar);
+          replaceIfCharLoggedIn(selectedChar);
         }
       }
 
@@ -84,7 +84,7 @@ module.exports = (srcPath) => {
         }
       }
 
-      function replaceIfSameCharacter(selectedChar) {
+      function replaceIfCharLoggedIn(selectedChar) {
         const player = state.PlayerManager.getPlayer(selectedChar);
         if (player) {
           bootPlayer(player, "Replaced by a new session.");

--- a/bundles/core-input-events/input-events/done.js
+++ b/bundles/core-input-events/input-events/done.js
@@ -11,7 +11,6 @@ module.exports = (srcPath) => {
   return {
     event: state => (socket, args) => {
       let player = args.player;
-      player.socket = socket;
       player.hydrate(state);
 
       player.socket.on('close', () => {

--- a/ranvier.json
+++ b/ranvier.json
@@ -17,5 +17,5 @@
   "minPlayerNameLength": 3,
 
   "maxCharacters": 3,
-  "allowMultiplay": false
+  "allowMultiplay": true
 }

--- a/ranvier.json
+++ b/ranvier.json
@@ -14,5 +14,8 @@
   "maxAccountNameLength": 20,
   "minAccountNameLength": 3,
   "maxPlayerNameLength": 20,
-  "minPlayerNameLength": 3
+  "minPlayerNameLength": 3,
+
+  "maxCharacters": 3,
+  "allowMultiplay": false
 }

--- a/ranvier.json
+++ b/ranvier.json
@@ -17,5 +17,5 @@
   "minPlayerNameLength": 3,
 
   "maxCharacters": 3,
-  "allowMultiplay": true
+  "allowMultiplay": false
 }

--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -12,7 +12,7 @@ class PlayerManager extends EventEmitter {
   }
 
   getPlayer(name) {
-    return this.players.get(name);
+    return this.players.get(name.toLowerCase());
   }
 
   addPlayer(player) {


### PR DESCRIPTION
Looks like there are some merge conflicts that I will try to fix on my end before pushing this up again.

Fixed #76 and made multiplay and max characters per account configurable.

Behavior for multiplay-allowed:
* Boots the old character and logs in a new session if you try to log in as a character that is already online.
* Else, lets you sign into the new and old character at once.

Behavior for multiplay-banned:
* Lets you sign into your account without logging off an old player, but as soon as you select the character it will kick your old char.