### PR TITLE
Grouping commands/functionality

### DIFF
--- a/bundles/ranvier-areas/areas/limbo/quests.js
+++ b/bundles/ranvier-areas/areas/limbo/quests.js
@@ -13,13 +13,14 @@ module.exports = (srcPath) => {
     1: {
       config: {
         title: "A Journey Begins",
+        level: 1,
         desc: `A voice whispers to you: Welcome to the world, young one. This is a dangerous and deadly place, you should arm yourself.
 
  - Use '<white>get sword chest</white>' and '<white>get vest chest</white>' to get some gear.
  - Equip it using '<white>wield sword</white>' and '<white>wear vest</white>'`,
         autoComplete: true,
         reward: (quest, player) => {
-          player.emit('experience', LevelUtil.mobExp(player.level) * 5);
+          player.emit('experience', LevelUtil.mobExp(quest.level) * 5);
           say(player, `<b><cyan>Hint: You can use the '<white>tnl</white>' or '<white>level</white>' commands to see how much experience you need to level.</cyan>`, 80);
 
           say(player);
@@ -55,12 +56,13 @@ module.exports = (srcPath) => {
     2: {
       config: {
         title: "One Cheese Please",
+        level: 1,
         desc: `A rat's squeaks seem to indicate it wants some cheese. You check around the area, maybe someone has left some lying around.
 
 Once you find some bring it back to the rat, use '<white>quest log</white>' to find the quest number, then complete the quest with '<white>quest complete #</white>'`,
         repeatable: true,
         reward: (quest, player) => {
-          player.emit('experience', LevelUtil.mobExp(player.level) * 3);
+          player.emit('experience', LevelUtil.mobExp(quest.level) * 3);
           say(player);
           say(player, `<b><cyan>Hint: NPCs with quests available have <white>[</white><yellow>!</yellow><white>]</white> in front of their name, <white>[</white><yellow>?</yellow><white>]</white> means you have a quest ready to turn in, and <white>[</white><yellow>%</yellow><white>]</white> means you have a quest in progress.</cyan>`, 80);
         }
@@ -81,6 +83,7 @@ Once you find some bring it back to the rat, use '<white>quest log</white>' to f
     3: {
       config: {
         title: "Self Defense 101",
+        level: 2,
         requires: [ "limbo:1" ],
         autoComplete: true,
         desc: `A voice whispers to you: It would be wise to practice protecting yourself. There are a number of training dummies in this area that, while not pushovers, will not be too difficult.
@@ -88,7 +91,7 @@ Once you find some bring it back to the rat, use '<white>quest log</white>' to f
 - Use '<white>attack dummy</white>' to start combat against the training dummy
 - Once it's dead any loot it drops will be in its corpse on the ground. You can use '<white>look in corpse</white>' to check again or '<white>get all corpse</white>' to retrieve your loot.`,
         reward: (quest, player) => {
-          player.emit('experience', LevelUtil.mobExp(player.level) * 5);
+          player.emit('experience', LevelUtil.mobExp(quest.level) * 5);
 
           say(player, `<b><cyan>Hint: You can get the loot from enemies with '<white>get <item> corpse</white>' but be quick about it, the corpse will decay after some time.</cyan>`, 80);
         }

--- a/bundles/ranvier-channels/channels.js
+++ b/bundles/ranvier-channels/channels.js
@@ -5,6 +5,7 @@ module.exports = (srcPath) => {
   const AudienceArea = require(srcPath + 'ChannelAudience/Area');
   const AudienceRoom = require(srcPath + 'ChannelAudience/Room');
   const AudiencePrivate = require(srcPath + 'ChannelAudience/Private');
+  const AudienceParty = require(srcPath + 'ChannelAudience/Party');
   const Channel = require(srcPath + 'Channel');
 
   return [
@@ -59,6 +60,22 @@ module.exports = (srcPath) => {
 
         target: function (sender, target, message, colorify) {
           return colorify(`Someone yells from nearby, '${message}'`);
+        }
+      }
+    }),
+
+    new Channel({
+      name: 'gtell',
+      color: ['bold', 'green'],
+      description: 'Send a message to everyone in your group, anywhere in the game',
+      audience: new AudienceParty(),
+      formatter: {
+        sender: function (sender, target, message, colorify) {
+          return colorify(`You tell the group, '${message}'`);
+        },
+
+        target: function (sender, target, message, colorify) {
+          return colorify(`${sender.name} tells the group, '${message}'`);
         }
       }
     }),

--- a/bundles/ranvier-combat/behaviors/npc/lootable.js
+++ b/bundles/ranvier-combat/behaviors/npc/lootable.js
@@ -48,18 +48,32 @@ module.exports = srcPath => {
           if (currencies) {
             currencies.forEach(currency => {
               const friendlyName = currency.name.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
-              B.sayAt(killer, `<green>You receive currency: <b><white>[${friendlyName}]</white></b> x${currency.amount}.`);
-              if (!killer.getMeta('currencies')) {
-                killer.setMeta('currencies', {});
-              }
-
               const key = `currencies.${currency.name}`;
-              killer.setMeta(key, (killer.getMeta(key) || 0) + currency.amount);
-            });
-            killer.save();
-          }
 
-          state.CommandManager.get('look').execute(corpse.uuid, killer);
+              // distribute currency among group members in the same room
+              const recipients = (killer.party ? [...killer.party] : [killer]).filter(recipient => {
+                return recipient.room === killer.room;
+              });;
+
+              let remaining = currency.amount;
+              for (const recipient of recipients) {
+                // Split currently evenly amount recipients.  The way the math works out the leader
+                // of the party will get any remainder if the currency isn't divisible evenly
+                const amount = Math.floor(remaining / recipients.length) + (remaining % recipients.length);
+                remaining -= amount;
+
+                B.sayAt(recipient, `<green>You receive currency: <b><white>[${friendlyName}]</white></b> x${amount}.`);
+
+                if (!recipient.getMeta('currencies')) {
+                  recipient.setMeta('currencies', {});
+                }
+                recipient.setMeta(key, (recipient.getMeta(key) || 0) + amount);
+                recipient.save();
+
+                state.CommandManager.get('look').execute(corpse.uuid, recipient);
+              }
+            });
+          }
         }
       }
     }

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -37,7 +37,7 @@ module.exports = (srcPath) => {
           // player actions
           if (target.getAttribute('health') <= 0) {
 
-            Broadcast.sayAt(this, `<bold>${target.name} is <red>Dead</red>!</bold>`);
+            Broadcast.sayAt(this, `<b>${target.name} is <red>Dead</red>!</b>`);
 
             handleDeath(state, target, this);
             if (target.isNpc) {
@@ -95,7 +95,7 @@ module.exports = (srcPath) => {
               // Set up helper functions for health-bar-building.
               const getHealthPercentage = entity => Math.floor((entity.getAttribute('health') / entity.getMaxAttribute('health')) * 100);
               const formatProgressBar = (name, progress, entity) =>
-                `<bold>${leftPad(name, nameWidth)}</bold>: ${progress} <bold>${entity.getAttribute('health')}/${entity.getMaxAttribute('health')}</bold>`;
+                `<b>${leftPad(name, nameWidth)}</b>: ${progress} <b>${entity.getAttribute('health')}/${entity.getMaxAttribute('health')}</b>`;
 
               // Build player health bar.
               let currentPerc = getHealthPercentage(promptee);
@@ -140,13 +140,34 @@ module.exports = (srcPath) => {
 
         let buf = '';
         if (damage.source) {
-          buf = `Your <bold>${damage.source.name}</bold> hit`;
+          buf = `Your <b>${damage.source.name}</b> hit`;
         } else {
           buf = "You hit";
         }
 
-        buf += ` <bold>${target.name}</bold> for <bold>${damage.finalAmount}</bold> damage.`;
+        buf += ` <b>${target.name}</b> for <b>${damage.finalAmount}</b> damage.`;
         Broadcast.sayAt(this, buf);
+
+        // show damage to party members
+        if (!this.party) {
+          return;
+        }
+
+        for (const member of this.party) {
+          if (member === this || member.room !== this.room) {
+            continue;
+          }
+
+          let buf = '';
+          if (damage.source) {
+            buf = `${this.name} <b>${damage.source.name}</b> hit`;
+          } else {
+            buf = `${this.name} hit`;
+          }
+
+          buf += ` <b>${target.name}</b> for <b>${damage.finalAmount}</b> damage.`;
+          Broadcast.sayAt(member, buf);
+        }
       },
 
       /**
@@ -160,14 +181,36 @@ module.exports = (srcPath) => {
 
         let buf = '';
         if (heal.source) {
-          buf = `Your <bold>${heal.source.name}</bold> healed`;
+          buf = `Your <b>${heal.source.name}</b> healed`;
         } else {
           buf = "You heal";
         }
 
-        buf += '<bold> ' + (target === this ? 'Yourself' : `${target.name}`) + '</bold>';
-        buf += ` for <bold><green>${heal.finalAmount}</green></bold> ${heal.attribute}.`;
+        buf += '<b> ' + (target === this ? 'Yourself' : `${target.name}`) + '</b>';
+        buf += ` for <b><green>${heal.finalAmount}</green></b> ${heal.attribute}.`;
         Broadcast.sayAt(this, buf);
+
+        // show heals to party members
+        if (!this.party) {
+          return;
+        }
+
+        for (const member of this.party) {
+          if (member === this || member.room !== this.room) {
+            continue;
+          }
+
+          let buf = '';
+          if (damage.source) {
+            buf = `${this.name} <b>${damage.source.name}</b> healed`;
+          } else {
+            buf = `${this.name} healed`;
+          }
+
+          buf += ` <b>${target.name}</b>`;
+          buf += ` for <b><green>${heal.finalAmount}</green></b> ${heal.attribute}.`;
+          Broadcast.sayAt(member, buf);
+        }
       },
 
       damaged: state => function (damage) {
@@ -177,17 +220,42 @@ module.exports = (srcPath) => {
 
         let buf = '';
         if (damage.attacker) {
-          buf = `<bold>${damage.attacker.name}</bold>`;
+          buf = `<b>${damage.attacker.name}</b>`;
         }
 
         if (damage.source) {
-          buf += (damage.attacker ? "'s " : "") + `<bold>${damage.source.name}</bold>`;
+          buf += (damage.attacker ? "'s " : " ") + `<b>${damage.source.name}</b>`;
         } else if (!damage.attacker) {
           buf += "Something";
         }
 
-        buf += ` hit <bold>You</bold> for <bold><red>${damage.finalAmount}</red></bold> damage`;
+        buf += ` hit <b>You</b> for <b><red>${damage.finalAmount}</red></b> damage`;
         Broadcast.sayAt(this, buf);
+
+        // show damage to party members
+        if (!this.party) {
+          return;
+        }
+
+        for (const member of this.party) {
+          if (member === this || member.room !== this.room) {
+            continue;
+          }
+
+          let buf = '';
+          if (damage.attacker) {
+            buf = `<b>${damage.attacker.name}</b>`;
+          }
+
+          if (damage.source) {
+            buf += (damage.attacker ? "'s " : ' ') + `<b>${damage.source.name}</b>`;
+          } else if (!damage.attacker) {
+            buf += "Something";
+          }
+
+          buf += ` hit <b>${this.name}</b> for <b><red>${damage.finalAmount}</red></b> damage`;
+          Broadcast.sayAt(member, buf);
+        }
       },
 
       /**
@@ -198,6 +266,11 @@ module.exports = (srcPath) => {
         if (killer !== this) {
           Broadcast.sayAt(this, `You were killed by ${killer.name}.`);
         }
+
+        if (this.party) {
+          Broadcast.sayAt(this.party, `<b><green>${this.name} was killed!</green></b>`);
+        }
+
         this.setAttributeToMax('health');
         Broadcast.sayAt(this, "Whoops, that sucked!");
         Broadcast.prompt(this);
@@ -208,10 +281,6 @@ module.exports = (srcPath) => {
        * @param {Character} target
        */
       deathblow: state => function (target, skipParty) {
-        if (target && !this.isNpc) {
-          Broadcast.sayAt(this, `<bold><red>You killed ${target.name}!`);
-        }
-
         const xp = LevelUtil.mobExp(target.level);
         if (this.party && !skipParty) {
           // if they're in a party proxy the deathblow to all members of the party in the same room.
@@ -221,9 +290,14 @@ module.exports = (srcPath) => {
               member.emit('deathblow', target, true);
             }
           }
-        } else {
-          this.emit('experience', xp);
+          return;
         }
+
+        if (target && !this.isNpc) {
+          Broadcast.sayAt(this, `<b><red>You killed ${target.name}!`);
+        }
+
+        this.emit('experience', xp);
       }
     }
   };
@@ -245,7 +319,6 @@ module.exports = (srcPath) => {
   }
 
   function handleDeath(state, deadEntity, killer) {
-
     deadEntity.combatants.forEach(combatant => {
       deadEntity.removeCombatant(combatant);
       combatant.removeCombatant(deadEntity);
@@ -266,8 +339,8 @@ module.exports = (srcPath) => {
     }
 
     const othersDeathMessage = killer ?
-      `<bold><red>${deadEntity.name} collapses to the ground, dead at the hands of ${killer.name}.</bold></red>` :
-      `<bold><red>${deadEntity.name} collapses to the ground, dead</bold></red>`;
+      `<b><red>${deadEntity.name} collapses to the ground, dead at the hands of ${killer.name}.</b></red>` :
+      `<b><red>${deadEntity.name} collapses to the ground, dead</b></red>`;
 
     Broadcast.sayAtExcept(
       deadEntity.room,
@@ -275,8 +348,15 @@ module.exports = (srcPath) => {
       (killer ? [killer, deadEntity] : deadEntity));
 
     deadEntity.emit('killed', killer || deadEntity);
+
     if (!killer.isNpc) {
-      Broadcast.prompt(killer);
+      if (killer.party) {
+        for (const member of killer.party) {
+          Broadcast.prompt(member);
+        }
+      } else {
+        Broadcast.prompt(killer);
+      }
     }
   }
 

--- a/bundles/ranvier-commands/commands/get.js
+++ b/bundles/ranvier-commands/commands/get.js
@@ -7,7 +7,7 @@ module.exports = (srcPath) => {
 
   return {
     usage: 'get <item> [container]',
-    aliases: [ 'take', 'grab', 'pick' ],
+    aliases: [ 'take', 'pick' ],
     command : (state) => (args, player) => {
       args = args.trim();
 

--- a/bundles/ranvier-commands/commands/group.js
+++ b/bundles/ranvier-commands/commands/group.js
@@ -1,0 +1,186 @@
+'use strict';
+
+module.exports = srcPath => {
+  const B = require(srcPath + 'Broadcast');
+  const Parser = require(srcPath + 'CommandParser').CommandParser;
+  const say = B.sayAt;
+
+  const PartyCommands = (state, player) => {
+    return [
+      {
+        name: 'create',
+        run(args) {
+          if (player.party) {
+            return say(player, "You're already in a group.");
+          }
+
+          state.PartyManager.create(player);
+          say(player, "<b><green>You created a group, invite players with '<white>group invite <name></white>'</green></b>");
+        }
+      },
+
+      {
+        name: 'invite',
+        run(args) {
+          if (!player.party) {
+            return say(player, "You don't have a group, create one with '<b>group create</b>'.");
+          }
+
+          if (player.party && player !== player.party.leader) {
+            return say(player, "You aren't the leader of the group.");
+          }
+
+          if (!args.length) {
+            return say(player, "Invite whom?");
+          }
+
+          const target = Parser.parseDot(args, player.room.players);
+
+          if (target === player) {
+            return say(player, "You ask yourself if you want to join your own group. You humbly accept.");
+          }
+
+          if (!target) {
+            return say(player, "They aren't here.");
+          }
+
+          if (target.party) {
+            return say(player, "They are already in a group.");
+          }
+
+          say(target, `<b><green>${player.name} invited you to join their group. Join/decline with '<white>group join/decline ${player.name}</white>'</green></b>`);
+          say(player, `<b><green>You invite ${target.name} to join your group.</green></b>`);
+          player.party.invite(target);
+          B.prompt(target);
+        }
+      },
+
+      {
+        name: 'disband',
+        run(args) {
+          if (!player.party) {
+            return say(player, "You aren't in a group.");
+          }
+
+          if (player !== player.party.leader) {
+            return say(player, "You aren't the leader of the group.");
+          }
+
+          if (!args || args !== 'sure') {
+            return say(player, `<b><green>You have to confirm disbanding your group with '<white>group disband sure</white>'</green></b>`);
+          }
+
+          say(player.party, '<b><green>Your group was disbanded!</green></b>');
+          state.PartyManager.disband(player.party);
+        }
+      },
+
+      {
+        name: 'join',
+        run(args) {
+          if (!args.length) {
+            return say(player, "Join whose group?");
+          }
+
+          const target = Parser.parseDot(args, player.room.players);
+
+          if (!target) {
+            return say(player, "They aren't here.");
+          }
+
+          if (!target.party || target !== target.party.leader) {
+            return say(player, "They aren't leading a group.");
+          }
+
+          if (!target.party.isInvited(player)) {
+            return say(player, "They haven't invited you to join their group.");
+          }
+
+          say(player, `<b><green>You join ${target.name}'s group.</green></b>`);
+          say(target.party, `<b><green>${player.name} joined the group.</green></b>`);
+          target.party.add(player);
+          player.follow(target);
+        }
+      },
+
+      {
+        name: 'decline',
+        run(args) {
+          if (!args.length) {
+            return say(player, "Decline whose invite?");
+          }
+
+          const target = Parser.parseDot(args, player.room.players);
+
+          if (!target) {
+            return say(player, "They aren't here.");
+          }
+
+          say(player, `<b><green>You decline to join ${target.name}'s group.</green></b>`);
+          say(target, `<b><green>${player.name} declined to join your group.</green></b>`);
+          target.party.removeInvite(player);
+        }
+      },
+
+      {
+        name: 'leave',
+        run() {
+          if (!player.party) {
+            return say(player, "You're not in a group.");
+          }
+
+          const party = player.party;
+          player.party.delete(player);
+          say(party, `<b><green>${player.name} left the group.</green></b>`);
+          say(player, '<b><green>You leave the group.</green></b>');
+        }
+      },
+
+      {
+        name: 'list',
+        run(args) {
+          if (!player.party) {
+            return say(player, "You're not in a group.");
+          }
+
+          say(player, '<b>' + B.center(80, 'Group', 'green', '-') + '</b>');
+          for (const member of player.party) {
+            let tag = '   ';
+            if (member === player.party.leader) {
+              tag = '[L]';
+            }
+            say(player, `<b><green>${tag} ${member.name}</green></b>`);
+          }
+        }
+      }
+    ];
+  };
+
+  return {
+    aliases: [ 'party' ],
+    command: state => (args, player) => {
+
+      if (!args || !args.length) {
+        args = 'list';
+      }
+
+      const parts = args.split(' ');
+      const commandName = parts[0];
+      args = parts.slice(1).join(' ');
+
+      let command = null;
+      for (const partyCommand of PartyCommands(state, player)) {
+        if (partyCommand.name.indexOf(commandName) === 0) {
+          command = partyCommand;
+          break;
+        }
+      }
+
+      if (!command) {
+        return say(player, "Not a valid party command.");
+      }
+
+      command.run(args);
+    }
+  };
+};

--- a/bundles/ranvier-input-events/input-events/done.js
+++ b/bundles/ranvier-input-events/input-events/done.js
@@ -12,6 +12,7 @@ module.exports = (srcPath) => {
     event: state => (socket, args) => {
       let player = args.player;
       player.hydrate(state);
+      player.save();
 
       player.socket.on('close', () => {
         Logger.log(player.name + ' has gone linkdead.');

--- a/docs/extending/areas/quests.md
+++ b/docs/extending/areas/quests.md
@@ -203,6 +203,9 @@ module.exports = (srcPath) => {
         title: "Find A Weapon",
         desc: "You're defenseless! Pick up the shiv from the chest by typing 'get shiv chest'",
 
+        // The level isn't _required_ but you may want it so you know how much of a reward to give
+        level: 1,
+
         // as soon as all goals are at 100% progress complete this quest. Defaults to false
         autoComplete: true,
 
@@ -210,7 +213,7 @@ module.exports = (srcPath) => {
         // do anything you want to reward the player, this example shows giving them some
         // experience
         reward: (quest, player) => {
-          player.emit('experience', LevelUtil.mobExp(player.level) * 5);
+          player.emit('experience', LevelUtil.mobExp(quest.level) * 5);
         }
       },
 
@@ -236,8 +239,9 @@ module.exports = (srcPath) => {
       config: {
         title: "One Cheese Please",
         desc: "A rat has tasked you with finding it some cheese, better get to it.",
+        level: 1,
         repeatable: true,
-        reward: (quest, player) => LevelUtil.mobExp(player.level) * 3
+        reward: (quest, player) => LevelUtil.mobExp(quest.level) * 3
       },
       goals: [
         {

--- a/ranvier
+++ b/ranvier
@@ -37,6 +37,7 @@ const HelpManager = require('./src/HelpManager');
 const ItemFactory = require('./src/ItemFactory');
 const ItemManager = require('./src/ItemManager');
 const MobFactory = require('./src/MobFactory');
+const PartyManager = require('./src/PartyManager');
 const PlayerManager = require('./src/PlayerManager');
 const QuestFactory = require('./src/QuestFactory');
 const RoomManager = require('./src/RoomManager');
@@ -59,7 +60,7 @@ commander
 
 // Set debug variable and encoding.
 // 'net' by default to help find possible server errors.
-process.env['NODE_DEBUG'] = 'net';
+process.env.NODE_DEBUG = 'net';
 process.stdin.setEncoding('utf8');
 
 const Logger = require('./src/Logger');
@@ -75,7 +76,7 @@ if (commander.prettyErrors) {
 // Set logging level based on CLI option or environment variable.
 const logLevel = commander.verbose ?
   'verbose' :
-  process.env['LOG_LEVEL'] || Config.get('logLevel') || 'debug';
+  process.env.LOG_LEVEL || Config.get('logLevel') || 'debug';
 
 Logger.setLevel(logLevel);
 
@@ -107,6 +108,7 @@ function init(restartServer) {
     ItemManager: new ItemManager(),
     MobBehaviorManager: new BehaviorManager(),
     MobFactory: new MobFactory(),
+    PartyManager: new PartyManager(),
     PlayerManager: new PlayerManager(),
     QuestFactory: new QuestFactory(),
     RoomBehaviorManager: new BehaviorManager(),

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -3,6 +3,7 @@
 const Broadcast = require('./Broadcast');
 const ChannelAudienceWorld = require('./ChannelAudience/World');
 const ChannelAudiencePrivate = require('./ChannelAudience/Private');
+const ChannelAudienceParty = require('./ChannelAudience/Party');
 
 /**
  * @property {ChannelAudience} audience People who receive messages from this channel
@@ -46,6 +47,10 @@ class Channel {
 
     this.audience.configure({ state, sender, message });
     const targets = this.audience.getBroadcastTargets();
+
+    if (this.audience instanceof ChannelAudienceParty && !targets.length) {
+      return Broadcast.sayAt(sender, "You aren't in a group.");
+    }
 
     // Allow audience to change message e.g., strip target name.
     message = this.audience.alterMessage(message);

--- a/src/ChannelAudience/Party.js
+++ b/src/ChannelAudience/Party.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const ChannelAudience = require('../ChannelAudience');
+
+/**
+ * Audience class representing other players in the same group as the sender
+ */
+class Party extends ChannelAudience {
+  getBroadcastTargets() {
+    if (!this.sender.party) {
+      return [];
+    }
+
+    return this.sender.party.getBroadcastTargets()
+      .filter(player => player !== this.sender);
+  }
+}
+
+module.exports = Party;

--- a/src/Character.js
+++ b/src/Character.js
@@ -38,8 +38,10 @@ class Character extends EventEmitter
     this.level = data.level || 1;
     this.room = data.room || null;
     this.attributes = new Attributes(data.attributes || null);
+
     this.followers = new Set();
     this.following = null;
+    this.party = null;
 
     this.effects = new EffectList(this, data.effects);
     this.skills = new Map();

--- a/src/Character.js
+++ b/src/Character.js
@@ -216,15 +216,19 @@ class Character extends EventEmitter
       return null;
     }
 
-    let possibleTargets = this.room.npcs;
+    let possibleTargets = [...this.room.npcs];
     if (this.getMeta('pvp')) {
-      possibleTargets = possibleTargets.concat(this.room.players);
+      possibleTargets = [...possibleTargets, ...this.room.players];
     }
 
     const target = Parser.parseDot(search, possibleTargets);
 
     if (!target) {
       return null;
+    }
+
+    if (target === this) {
+      throw new Error('You slap yourself in the face. Ouch!');
     }
 
     if (!target.isNpc && !target.getMeta('pvp')) {

--- a/src/Party.js
+++ b/src/Party.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Representation of an adventuring party
+ */
+class Party extends Set {
+  constructor(leader) {
+    super();
+    this.invited = new Set();
+    this.leader = leader;
+    this.add(leader);
+  }
+
+  delete(member) {
+    super.delete(member);
+    member.party = null;
+  }
+
+  add(member) {
+    super.add(member);
+    member.party = this;
+    this.invited.delete(member);
+  }
+
+  disband() {
+    for (const member of this) {
+      this.delete(member);
+    }
+  }
+
+  invite(target) {
+    this.invited.add(target);
+  }
+
+  isInvited(target) {
+    return this.invited.has(target);
+  }
+
+  removeInvite(target) {
+    this.invited.delete(target);
+  }
+
+  getBroadcastTargets() {
+    return [...this];
+  }
+}
+
+module.exports = Party;

--- a/src/PartyManager.js
+++ b/src/PartyManager.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const Party = require('./Party');
+
+class PartyManager extends Set {
+  create(leader) {
+    const party = new Party(leader);
+    this.add(party);
+  }
+
+  disband(party) {
+    this.delete(party);
+    party.disband();
+    party = null;
+  }
+}
+
+module.exports = PartyManager;

--- a/src/Quest.js
+++ b/src/Quest.js
@@ -16,6 +16,7 @@ class Quest extends EventEmitter {
       title: 'Missing Quest Title',
       desc: 'Missing Quest Description',
       requires: [],
+      level: 1,
       autoComplete: false,
       repeatable: false,
       reward: _ => {}


### PR DESCRIPTION
There is now a group command which has create/invite/join/decline/disband.

Group members in the same room:

* get credit for kills via the 'deathblow' event so they will get credit for quest kills, etc.
* get any currency dropped by a lootable npc distributed evenly between them
* See combat messages for other group members in combat

There's also a new channel: `gtell` to let group members communicate across the game