### PR TITLE
Usable behavior

### DIFF
--- a/bundles/ranvier-areas/areas/limbo/items.yml
+++ b/bundles/ranvier-areas/areas/limbo/items.yml
@@ -26,7 +26,7 @@
   roomDesc: "A wooden chest rests open in the corner, its hinges badly rusted."
   keywords: [ "wooden", "chest" ]
   description: "Time has not been kind to this chest. It seems to be held together solely by the dirt and rust."
-  items: [ "limbo:1", "limbo:6" ]
+  items: [ "limbo:1", "limbo:6", "limbo:7", "limbo:8" ]
   properties:
     noPickup: true
     maxItems: 2
@@ -64,3 +64,42 @@
   properties:
     stats:
       armor: 20
+- id: 7
+  name: "Potion of Health I"
+  roomDesc: "Potion of Health I"
+  keywords: [ "potion", "health" ]
+  level: 1
+  behaviors:
+    # usable has two variants: spell, and effect
+    usable:
+      # this is the spell variant, you specify a skill of type SPELL
+      spell: "potion"
+      # charges/destroyOnDepleted lets you create consumable items
+      # without specifying charges the item can be used forever
+      charges: 5
+      destroyOnDepleted: true
+      # cooldown before item can be used again
+      cooldown: 30
+      # spell configuration, spell can access it via this.options
+      options:
+        restores: 30
+        stat: "health"
+- id: 8
+  name: "Potion of Strength I"
+  roomDesc: "Potion of Strength I"
+  keywords: [ "potion", "strength" ]
+  level: 1
+  behaviors:
+    usable:
+      # this is the effect variant, you specify an effect name instead of a spell
+      effect: "potion.buff"
+      charges: 2
+      destroyOnDepleted: true
+      # effect config, see Effect docs. `name` is auto-populated with the item name
+      config:
+        description: "Increases strength by <b>10</b> for <b>15</b> seconds"
+        duration: 15000
+      # effect state, see Effect docs
+      state:
+        magnitude: 10
+        stat: "strength"

--- a/bundles/ranvier-areas/areas/limbo/loot-pools.yml
+++ b/bundles/ranvier-areas/areas/limbo/loot-pools.yml
@@ -1,8 +1,6 @@
 ---
-testa:
-  "limbo:1": 2
-testb:
-  "limbo:2": 5
+potions:
+  - "limbo:7": 10
+  - "limbo:8": 5
 junk:
-  - "limbo:testb"
   - "limbo:4": 50

--- a/bundles/ranvier-areas/areas/limbo/npcs.yml
+++ b/bundles/ranvier-areas/areas/limbo/npcs.yml
@@ -39,6 +39,7 @@
       # npc in the area can drop
       pools:
         - "limbo:junk"
+        - "limbo:potions"
         - "limbo:2": 25
   description: >-
     The training dummy is almost human shaped although slightly out of proportion. The material it's made of is hard to
@@ -58,4 +59,5 @@
           min: 50
           max: 100
       pools:
+        - "limbo:potions"
         - "limbo:5": 100

--- a/bundles/ranvier-classes/effects/potion.buff.js
+++ b/bundles/ranvier-classes/effects/potion.buff.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = srcPath => {
+  const Broadcast = require(srcPath + 'Broadcast');
+  const Flag = require(srcPath + 'EffectFlag');
+
+  return {
+    config: {
+      name: 'Potion Buff',
+      type: 'potion.buff',
+    },
+    flags: [Flag.BUFF],
+    state: {
+      stat: "strength",
+      magnitude: 1
+    },
+    modifiers: {
+      attributes: function (attribute, current) {
+        if (attribute !== this.state.stat) {
+          return current;
+        }
+
+        return current + this.state.magnitude;
+      }
+    },
+    listeners: {
+      effectActivated: function () {
+        Broadcast.sayAt(this.target, "You drink down the potion and feel more powerful!");
+      },
+
+      effectDeactivated: function () {
+        Broadcast.sayAt(this.target, "You feel less powerful.");
+      }
+    }
+  };
+};
+

--- a/bundles/ranvier-classes/skills/potion.js
+++ b/bundles/ranvier-classes/skills/potion.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Health potion item spell
+ */
+module.exports = (srcPath) => {
+  const Broadcast = require(srcPath + 'Broadcast');
+  const Heal = require(srcPath + 'Heal');
+  const SkillType = require(srcPath + 'SkillType');
+
+  return {
+    name: 'Potion',
+    type: SkillType.SPELL,
+    requiresTarget: true,
+    targetSelf: true,
+
+    run: state => function (args, player, target) {
+      const restorePercent = this.options.restore || 0;
+      const stat = this.options.stat || 'health';
+      const heal = new Heal({
+        attribute: stat,
+        amount: Math.round(player.getMaxAttribute('health') * (this.options.restores / 100)),
+        attacker: player,
+        source: this
+      });
+
+      Broadcast.sayAt(player, `<bold>You drink the potion and a warm feeling fills your body.</bold>`);
+      heal.commit(target);
+    },
+
+    info: function (player) {
+      return `Restores <b>${this.options.restores}%</b> of your total ${this.options.stat}.`;
+    }
+  };
+};

--- a/bundles/ranvier-commands/commands/look.js
+++ b/bundles/ranvier-commands/commands/look.js
@@ -160,8 +160,7 @@ module.exports = (srcPath) => {
       }
 
       if (usable.charges) {
-        const charges = Reflect.has(entity, 'charges') ? entity.charges : usable.charges;
-        Broadcast.sayAt(player, `There are ${charges} charges remaining.`);
+        Broadcast.sayAt(player, `There are ${usable.charges} charges remaining.`);
       }
     }
 

--- a/bundles/ranvier-commands/commands/look.js
+++ b/bundles/ranvier-commands/commands/look.js
@@ -112,7 +112,7 @@ module.exports = (srcPath) => {
       Broadcast.sayAt(player, ']');
   }
 
-  function lookEntity(player, args) {
+  function lookEntity(state, player, args) {
     const room = player.room;
 
     args = args.split(' ');
@@ -145,6 +145,26 @@ module.exports = (srcPath) => {
       Broadcast.sayAt(player, `You estimate that ${entity.name} will rot away in ${humanize(entity.timeUntilDecay)}.`);
     }
 
+    const usable = entity.getBehavior('usable');
+    if (usable) {
+      if (usable.spell) {
+        const useSpell = state.SpellManager.get(usable.spell);
+        if (useSpell) {
+          useSpell.options = usable.options;
+          Broadcast.sayAt(player, useSpell.info(player));
+        }
+      }
+
+      if (usable.effect && usable.config.description) {
+        Broadcast.sayAt(player, usable.config.description);
+      }
+
+      if (usable.charges) {
+        const charges = Reflect.has(entity, 'charges') ? entity.charges : usable.charges;
+        Broadcast.sayAt(player, `There are ${charges} charges remaining.`);
+      }
+    }
+
     if (entity instanceof Item && entity.type === ItemType.CONTAINER) {
       if (!entity.inventory || !entity.inventory.size) {
         return Broadcast.sayAt(player, `${entity.name} is empty.`);
@@ -167,7 +187,7 @@ module.exports = (srcPath) => {
       }
 
       if (args) {
-        return lookEntity(player, args);
+        return lookEntity(state, player, args);
       }
 
       lookRoom(state, player);

--- a/bundles/ranvier-commands/commands/use.js
+++ b/bundles/ranvier-commands/commands/use.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * Command for items with `usable` behavior. See bundles/ranvier-areas/areas/limbo/items.yml for
+ * example behavior implementation
+ */
+module.exports = srcPath => {
+  const Broadcast = require(srcPath + 'Broadcast');
+  const Logger = require(srcPath + 'Logger');
+  const { CommandParser } = require(srcPath + 'CommandParser');
+
+  return {
+    aliases: [ 'quaff', 'recite' ],
+    command: state => (args, player) => {
+      const say = message => Broadcast.sayAt(player, message);
+
+      if (!args.length) {
+        return say("Use what?");
+      }
+
+      const item = CommandParser.parseDot(args, player.inventory);
+
+      if (!item) {
+        return say("You don't have anything like that.");
+      }
+
+      const usable = item.getBehavior('usable');
+      if (!usable) {
+        return say("You can't use that.");
+      }
+
+      if (usable.charges) {
+        item.charges = !Reflect.has(item, 'charges') ? usable.charges : item.charges;
+
+        if (item.charges <= 0) {
+          return say(`You've used up all the magic in ${item.display}.`);
+        }
+      }
+
+      if (usable.spell) {
+        const useSpell = state.SpellManager.get(usable.spell);
+
+        if (!useSpell) {
+          Logger.error(`Item: ${item.entityReference} has invalid usable configuration.`);
+          return say("You can't use that.");
+        }
+
+        useSpell.options = usable.options;
+        if (usable.cooldown) {
+          useSpell.cooldownLength = usable.cooldown;
+        }
+
+        if (!useSpell.execute(/* args */ null, player)) {
+          // no need to broadcast here, Skill already broadcasts the error
+          return;
+        }
+      }
+
+      if (usable.effect) {
+        const effectConfig = Object.assign({
+          name: item.name
+        }, usable.config || {});
+        const effectState = usable.state || {};
+
+        let useEffect = state.EffectFactory.create(usable.effect, player, effectConfig, effectState);
+        if (!useEffect) {
+          Logger.error(`Item: ${item.entityReference} has invalid usable configuration.`);
+          return say("You can't use that.");
+        }
+
+        if (!player.addEffect(useEffect)) {
+          return say("Nothing happens.");
+        }
+      }
+
+      if (!usable.charges) {
+        return;
+      }
+
+      item.charges--;
+
+      if (usable.destroyOnDepleted && item.charges <= 0) {
+        say(`You used up all the magic in ${item.display} and it disappears in a puff of smoke.`);
+        state.ItemManager.remove(item);
+      }
+    }
+  };
+};

--- a/bundles/ranvier-commands/commands/use.js
+++ b/bundles/ranvier-commands/commands/use.js
@@ -29,12 +29,8 @@ module.exports = srcPath => {
         return say("You can't use that.");
       }
 
-      if (usable.charges) {
-        item.charges = !Reflect.has(item, 'charges') ? usable.charges : item.charges;
-
-        if (item.charges <= 0) {
-          return say(`You've used up all the magic in ${item.display}.`);
-        }
+      if ('charges' in usable && usable.charges <= 0) {
+        return say(`You've used up all the magic in ${item.display}.`);
       }
 
       if (usable.spell) {
@@ -73,13 +69,13 @@ module.exports = srcPath => {
         }
       }
 
-      if (!usable.charges) {
+      if (!('charges' in usable)) {
         return;
       }
 
-      item.charges--;
+      usable.charges--;
 
-      if (usable.destroyOnDepleted && item.charges <= 0) {
+      if (usable.destroyOnDepleted && usable.charges <= 0) {
         say(`You used up all the magic in ${item.display} and it disappears in a puff of smoke.`);
         state.ItemManager.remove(item);
       }

--- a/src/CommandParser.js
+++ b/src/CommandParser.js
@@ -164,6 +164,9 @@ class CommandParser {
         if (encountered === findNth) {
           return returnKey ? [key, entry] : entry;
         }
+        // if the keyword matched skip to next loop so we don't double increment
+        // the encountered counter
+        continue;
       }
 
       if (entry.name && entry.name.toLowerCase().includes(keyword)) {

--- a/src/EffectList.js
+++ b/src/EffectList.js
@@ -86,6 +86,7 @@ class EffectList {
     this.effects.add(effect);
     effect.emit('effectAdded');
     effect.on('remove', () => this.remove(effect));
+    return true;
   }
 
   /**

--- a/src/Item.js
+++ b/src/Item.js
@@ -177,9 +177,17 @@ class Item extends EventEmitter {
   }
 
   serialize() {
+    let behaviors = {};
+    for (const [key, val] of this.behaviors) {
+      behaviors[key] = val;
+    }
+
     return {
       entityReference: this.entityReference,
       inventory: this.inventory && this.inventory.serialize(),
+      // behaviors are serialized in case their config was modified during gameplay
+      // and that state needs to persist (charges of a scroll remaining, etc)
+      behaviors,
     };
   }
 }

--- a/src/Skill.js
+++ b/src/Skill.js
@@ -38,6 +38,7 @@ class Skill {
       run = _ => {},
       targetSelf = false,
       type = SkillType.SKILL,
+      options = {}
     } = config;
 
     this.configureEffect = configureEffect;
@@ -48,6 +49,7 @@ class Skill {
     this.info = info.bind(this);
     this.initiatesCombat = initiatesCombat;
     this.name = name;
+    this.options = options;
     this.requiresTarget = requiresTarget;
     this.resource = resource;
     this.run = run.bind(this);
@@ -68,7 +70,8 @@ class Skill {
 
     const cdEffect = this.onCooldown(player);
     if (this.cooldownLength && cdEffect) {
-      return Broadcast.sayAt(player, `${this.name} is on cooldown. ${humanize(cdEffect.remaining)} remaining.`);
+      Broadcast.sayAt(player, `${this.name} is on cooldown. ${humanize(cdEffect.remaining)} remaining.`);
+      return false;
     }
 
     if (this.requiresTarget && !target) {
@@ -84,19 +87,21 @@ class Skill {
         try {
           target = player.findCombatant(args);
         } catch (e) {
-          return Broadcast.sayAt(player, e.message);
+          Broadcast.sayAt(player, e.message);
+          return false;
         }
       }
 
       if (!target) {
-        return Broadcast.sayAt(player, `Use ${this.name} on whom?`);
+        Broadcast.sayAt(player, `Use ${this.name} on whom?`);
+        return false;
       }
     }
 
     if (this.resource.cost) {
       const paid = this.payResourceCost(player);
       if (!paid) {
-        return;
+        return false;
       }
     }
 
@@ -106,6 +111,7 @@ class Skill {
 
     this.run(args, player, target);
     this.cooldown(player);
+    return true;
   }
 
   /** Finds implicit targets.


### PR DESCRIPTION
This PR creates a `usable` behavior with two modes: spell and effect. For spell mode the item specifies the spell to cast on use with configuration for the spell. For effect mode the item configures which effect to apply and the effect config (duration, state, etc.). `usable` supports a charge system and `destroyOnDeplete` which, if true, will remove the item from the game once all its charges are used up.

See items.yml changes for example usage