### PR TITLE
Fix getting the starting room from RoomManager

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -207,7 +207,7 @@ class Player extends Character {
       let room = state.RoomManager.getRoom(this.room);
       if (!room) {
         Logger.warn(`WARNING: Player ${this.name} was saved to invalid room ${this.room}.`);
-        room = state.RoomManager.getStartingRoom();
+        room = state.RoomManager.startingRoom;
       }
 
       this.room = room;

--- a/src/RoomManager.js
+++ b/src/RoomManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Room = require('./Room');
+const Config = require('./Config');
 
 class RoomManager {
   constructor() {
@@ -38,6 +39,10 @@ class RoomManager {
     }
 
     return exits.pop();
+  }
+
+  getStartingRoom() {
+    return Config.get('startingRoom');
   }
 }
 

--- a/src/RoomManager.js
+++ b/src/RoomManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Room = require('./Room');
-const Config = require('./Config');
 
 class RoomManager {
   constructor() {

--- a/src/RoomManager.js
+++ b/src/RoomManager.js
@@ -40,10 +40,6 @@ class RoomManager {
 
     return exits.pop();
   }
-
-  getStartingRoom() {
-    return Config.get('startingRoom');
-  }
 }
 
 module.exports = RoomManager;


### PR DESCRIPTION
When a player is hydrated, if the player isn't in a valid room, a call to `state.RoomManager.getStartingRoom()` is made, which is undefined.