### PR TITLE
Use RoomBehaviorManager within the Room class

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -199,7 +199,7 @@ class Room extends EventEmitter {
     });
 
     for (let [behaviorName, config] of this.behaviors) {
-      let behavior = state.ItemBehaviorManager.get(behaviorName);
+      let behavior = state.RoomBehaviorManager.get(behaviorName);
       if (!behavior) {
         return;
       }


### PR DESCRIPTION
Rooms were trying to load behaviors from `ItemBehaviorManager`, so this fix will adjust that.