### PR TITLE
Extract Data.isScriptFile method

### DIFF
--- a/src/BundleManager.js
+++ b/src/BundleManager.js
@@ -337,7 +337,7 @@ class BundleManager {
 
     for (const commandFile of files) {
       const commandPath = commandsDir + commandFile;
-      if (!fs.statSync(commandPath).isFile() || !commandFile.match(/js$/)) {
+      if (!Data.isScriptFile(commandPath, commandFile)) {
         continue;
       }
 
@@ -426,7 +426,7 @@ class BundleManager {
 
     for (const eventFile of files) {
       const eventPath = inputEventsDir + eventFile;
-      if (!fs.statSync(eventPath).isFile() || !eventFile.match(/js$/)) {
+      if (!Data.isScriptFile(eventPath, eventFile)) {
         continue;
       }
 
@@ -458,7 +458,7 @@ class BundleManager {
 
       for (const behaviorFile of files) {
         const behaviorPath = typeDir + behaviorFile;
-        if (!fs.statSync(behaviorPath).isFile() || !behaviorFile.match(/js$/)) {
+        if (!Data.isScriptFile(behaviorPath, behaviorFile)) {
           continue;
         }
 
@@ -493,7 +493,7 @@ class BundleManager {
 
     for (const effectFile of files) {
       const effectPath = effectsDir + effectFile;
-      if (!fs.statSync(effectPath).isFile() || !effectFile.match(/js$/)) {
+      if (!Data.isScriptFile(effectPath, effectFile)) {
         continue;
       }
 
@@ -517,7 +517,7 @@ class BundleManager {
 
     for (const skillFile of files) {
       const skillPath = skillsDir + skillFile;
-      if (!fs.statSync(skillPath).isFile() || !skillFile.match(/js$/)) {
+      if (!Data.isScriptFile(skillPath, skillFile)) {
         continue;
       }
 
@@ -551,7 +551,7 @@ class BundleManager {
 
     for (const classFile of files) {
       const classPath = classesDir + classFile;
-      if (!fs.statSync(classPath).isFile() || !classFile.match(/js$/)) {
+      if (!Data.isScriptFile(classPath, classFile)) {
         continue;
       }
 

--- a/src/Data.js
+++ b/src/Data.js
@@ -120,6 +120,10 @@ class Data {
     }
   }
 
+  static isScriptFile(path, file) {
+    return fs.statSync(path).isFile() && file.match(/js$/);
+  }
+
   /**
    * load the MOTD for the intro screen
    * @return string

--- a/src/Data.js
+++ b/src/Data.js
@@ -120,7 +120,14 @@ class Data {
     }
   }
 
+  /**
+   * Determine whether or not a path leads to a legitimate JS file or not.
+   * @param {string} path
+   * @param {string} [file]
+   * @return {boolean}
+   */
   static isScriptFile(path, file) {
+    file = file || path;
     return fs.statSync(path).isFile() && file.match(/js$/);
   }
 


### PR DESCRIPTION
Small refactor.

This code was repeated a fair amount, and I can think of instances where a bundle may want to use this method when loading something dynamically.

I decided to move it to the Data class since it's a pure-ish function and not exclusively related to loading a bundle, so thought it was a good candidate for a static utility method.