### PR TITLE
Fix the get command, closes #240

### DIFF
--- a/bundles/ranvier-commands/commands/get.js
+++ b/bundles/ranvier-commands/commands/get.js
@@ -45,8 +45,12 @@ module.exports = (srcPath) => {
         }
 
         if (container.type !== ItemType.CONTAINER) {
-          return Broadcast.sayAt(player, `${container.name} isn't a container.`);
+          return Broadcast.sayAt(player, `${container.display} isn't a container.`);
         }
+
+        if (container.closed) {
+          return Broadcast.sayAt(player, `${container.display} is closed.`);
+      }
 
         search = parts[0];
         source = container.inventory;
@@ -89,9 +93,6 @@ module.exports = (srcPath) => {
     }
 
     if (container) {
-      if (container.closed) {
-        return Broadcast.sayAt(player, `${container.display} is closed.`);
-      }
       container.removeItem(item);
     } else {
       player.room.removeItem(item);

--- a/bundles/ranvier-commands/commands/get.js
+++ b/bundles/ranvier-commands/commands/get.js
@@ -39,7 +39,9 @@ module.exports = (srcPath) => {
         search = parts[0];
         source = player.room.items;
       } else {
-        container = Parser.parseDot(parts[1], player.room.items);
+      //Newest containers should go first, so that if you type get all corpse you get from the 
+      // most recent corpse. See issue #247.
+        container = Parser.parseDot(parts[1], [...player.room.items].reverse());
         if (!container) {
           return Broadcast.sayAt(player, "You don't see anything like that here.");
         }
@@ -50,7 +52,7 @@ module.exports = (srcPath) => {
 
         if (container.closed) {
           return Broadcast.sayAt(player, `${container.display} is closed.`);
-      }
+        }
 
         search = parts[0];
         source = container.inventory;


### PR DESCRIPTION
When trying to get all items from a closed container, only one failure message is now displayed.