### PR TITLE
Multiple item slots

### DIFF
--- a/bundles/ranvier-areas/areas/limbo/items.yml
+++ b/bundles/ranvier-areas/areas/limbo/items.yml
@@ -27,9 +27,9 @@
   roomDesc: "A wooden chest rests in the corner, its hinges badly rusted."
   keywords: [ "wooden", "chest" ]
   description: "Time has not been kind to this chest. It seems to be held together solely by the dirt and rust."
-  items: [ "limbo:1", "limbo:6", "limbo:7", "limbo:8", "limbo:leather_gauntlet" ]
+  items: [ "limbo:1", "limbo:6", "limbo:7", "limbo:8", "limbo:leather_gauntlet", "limbo:leather_gauntlet" ]
   closed: true
-  maxItems: 5
+  maxItems: 6
   properties:
     noPickup: true
 - id: 4
@@ -59,7 +59,7 @@
     stats:
       strength: 2
       stamina: 2
-  behaviors: 
+  behaviors:
     sellable:
       value: 30
       currency: gold
@@ -76,7 +76,7 @@
   properties:
     stats:
       armor: 20
-  behaviors: 
+  behaviors:
     sellable:
       value: 30
       currency: gold
@@ -154,7 +154,7 @@
   properties:
     stats:
       armor: 10
-  behaviors: 
+  behaviors:
     sellable:
       value: 30
       currency: gold

--- a/bundles/ranvier-areas/areas/limbo/items.yml
+++ b/bundles/ranvier-areas/areas/limbo/items.yml
@@ -27,7 +27,7 @@
   roomDesc: "A wooden chest rests in the corner, its hinges badly rusted."
   keywords: [ "wooden", "chest" ]
   description: "Time has not been kind to this chest. It seems to be held together solely by the dirt and rust."
-  items: [ "limbo:1", "limbo:6", "limbo:7", "limbo:8" ]
+  items: [ "limbo:1", "limbo:6", "limbo:7", "limbo:8", "limbo:leather_gauntlet" ]
   closed: true
   maxItems: 5
   properties:
@@ -176,3 +176,20 @@
   maxItems: 5
   properties:
     noPickup: true
+- id: leather_gauntlet
+  name: "Leather Gauntlet"
+  keywords: ["leather", "gauntlet", "glove"]
+  roomDesc: "Leather Gauntlet"
+  type: ARMOR
+  slot: ['right hand', 'left hand']
+  description: 'This gauntlet is made of overlapping leather bands that provide protection for ones hands and forearms. Looks pretty stylish, too.'
+  quality: common
+  level: 1
+  itemLevel: 1
+  properties:
+    stats:
+      armor: 8
+  behaviors:
+    sellable:
+      value: 25
+      currency: gold

--- a/bundles/ranvier-commands/commands/wear.js
+++ b/bundles/ranvier-commands/commands/wear.js
@@ -23,7 +23,7 @@ module.exports = (srcPath) => {
         return say(player, "You aren't carrying anything like that.");
       }
 
-      if (!item.slot) {
+      if (!item.slots || !item.slots.length) {
         return say(player, `You can't wear ${item.display}.`);
       }
 
@@ -35,20 +35,21 @@ module.exports = (srcPath) => {
         player.equip(item);
       } catch (err) {
         if (err instanceof EquipSlotTakenError) {
-          const conflict = player.equipment.get(item.slot);
-          return say(player, `You will have to remove ${conflict.display} first.`);
+          const conflict = item.slots.every(slot => player.equipment.has(slot));
+          const firstItem = player.equipment.get(item.slots[0]);
+          return say(player, `You will have to remove ${firstItem.display} first.`);
         }
 
         return Logger.error(err);
       }
 
       say(player, `<green>You equip:</green> ${item.display}<green>.</green>`);
-
+      const openSlot = item.slots.find(slot => !player.equipment.has(slot));
       item.emit('equip', player);
-      player.emit('equip', item.slot, item);
+      player.emit('equip', openSlot, item);
 
       if (item.properties && item.properties.stats) {
-        player.addEffect(createAttributeEffect(state, player, item.slot, item.properties.stats));
+        player.addEffect(createAttributeEffect(state, player, openSlot, item.properties.stats));
       }
     }
   };

--- a/bundles/ranvier-commands/commands/wear.js
+++ b/bundles/ranvier-commands/commands/wear.js
@@ -35,9 +35,9 @@ module.exports = (srcPath) => {
         player.equip(item);
       } catch (err) {
         if (err instanceof EquipSlotTakenError) {
-          const conflict = item.slots.every(slot => player.equipment.has(slot));
-          const firstItem = player.equipment.get(item.slots[0]);
-          return say(player, `You will have to remove ${firstItem.display} first.`);
+          const conflicts = item.slots.filter(slot => player.equipment.has(slot));
+          const conflictingItems = conflicts.map(slot => player.equipment.get(slot).display).join(', or ');
+          return say(player, `You will have to remove ${conflictingItems} first.`);
         }
 
         return Logger.error(err);

--- a/bundles/ranvier-lib/lib/ItemUtil.js
+++ b/bundles/ranvier-lib/lib/ItemUtil.js
@@ -31,7 +31,7 @@ exports.renderItem = function renderItem(state, item, player) {
       buf += sprintf('| %-36s |\r\n', `(${dps.toPrecision(2)} damage per second)`);
       break;
     case ItemType.ARMOR:
-      buf += sprintf('| %-36s |\r\n', item.slot[0].toUpperCase() + item.slot.slice(1));
+      buf += sprintf('| %-36s |\r\n', item.slots.map(slot => slot[0].toUpperCase() + slot.slice(1)).join(', '));
       break;
     case ItemType.CONTAINER:
       buf += sprintf('| %-36s |\r\n', `Holds ${item.maxItems} items`);

--- a/src/Character.js
+++ b/src/Character.js
@@ -266,7 +266,8 @@ class Character extends EventEmitter
   }
 
   equip(item) {
-    if (this.equipment.has(item.slot)) {
+    const openSlot = item.slots.find(slot => !this.equipment.has(slot));
+    if (!openSlot) {
       throw new EquipSlotTakenError();
     }
 
@@ -274,7 +275,7 @@ class Character extends EventEmitter
       this.removeItem(item);
     }
 
-    this.equipment.set(item.slot, item);
+    this.equipment.set(openSlot, item);
     item.isEquipped = true;
   }
 

--- a/src/Item.js
+++ b/src/Item.js
@@ -62,7 +62,7 @@ class Item extends EventEmitter {
     this.room        = item.room || null;
     this.roomDesc    = item.roomDesc || '';
     this.script      = item.script || null;
-    this.slot        = item.slot || null;
+    this.slots       = Array.isArray(item.slot) ? item.slot : [(item.slot || null)];
     this.type        = typeof item.type === 'string' ? ItemType[item.type] : (item.type || ItemType.OBJECT);
     this.uuid        = item.uuid || uuid.v4();
     this.closeable   = item.closeable || item.closed || item.locked || false;


### PR DESCRIPTION
Resolves #249 .

The `slot` property in each items YAML definition can now be a string or array of strings.
The appropriate `EquipError` is thrown if all of the listed slots are occupied by equipped items.