### PR TITLE
Removing [a-z] filter from command

### DIFF
--- a/src/CommandParser.js
+++ b/src/CommandParser.js
@@ -25,7 +25,7 @@ class CommandParser {
 
     const parts = data.split(' ');
 
-    const command = parts.shift().replace(/[^a-z]/i, '').toLowerCase();
+    const command = parts.shift().toLowerCase();
     if (!command.length) {
       throw new InvalidCommandError();
     }


### PR DESCRIPTION
Removing [a-z] filter from command so that we can use alias as - . ; or anything like that