### PR TITLE
Fix for issue with recall: no energy attribute is causing issues

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "name": "Launch Program",
             "program": "${workspaceRoot}\\ranvier",
             "args": ["-v"],
-            "console": "integratedTerminal",
+            "console": "externalTerminal",
             "cwd": "${workspaceRoot}"
         },
         {

--- a/bundles/ranvier-commands/commands/recall.js
+++ b/bundles/ranvier-commands/commands/recall.js
@@ -11,13 +11,6 @@ module.exports = srcPath => {
         return B.sayAt(player, 'You do not have a home waypoint set.');
       }
 
-      if (player.getAttribute('energy') < (player.getMaxAttribute('energy') / 3)) {
-        return B.sayAt(player, 'You do not have enough energy to recall.');
-      }
-
-      const cost = Math.round(player.getMaxAttribute('energy') / 3);
-      player.lowerAttribute('energy', cost);
-
       B.sayAt(player, '<b><cyan>You pray to the gods to be returned home and are consumed by a bright blue light.</cyan></b>');
       B.sayAtExcept(player.room, `<b><cyan>${player.name} disappears in a flash of blue light.</cyan></b>`, [player]);
 

--- a/bundles/ranvier-input-events/input-events/finish-player.js
+++ b/bundles/ranvier-input-events/input-events/finish-player.js
@@ -20,8 +20,7 @@ module.exports = (srcPath) => {
           agility: 20,
           intellect: 20,
           stamina: 20,
-          armor: 0,
-          energy: 20
+          armor: 0
         }
       });
 

--- a/bundles/ranvier-input-events/input-events/finish-player.js
+++ b/bundles/ranvier-input-events/input-events/finish-player.js
@@ -21,6 +21,7 @@ module.exports = (srcPath) => {
           intellect: 20,
           stamina: 20,
           armor: 0,
+          energy: 20
         }
       });
 


### PR DESCRIPTION
Fix issues with VSCode launch.json config
Fix issue with recall.js checking the energy attribute (it's never created when you create a new character), throwing an error.

To reproduce the error: create a new paladin, waypoint save, waypoint home, then try to recall.