### PR TITLE
Fixes #280 display websocket port.

### DIFF
--- a/bundles/ranvier-telnet/server-events/telnet-server.js
+++ b/bundles/ranvier-telnet/server-events/telnet-server.js
@@ -57,7 +57,7 @@ module.exports = srcPath => {
           process.exit(1);
         });
 
-        Logger.log(`Server started on port: ${commander.port}...`);
+        Logger.log(`Telnet server started on port: ${commander.port}...`);
       },
 
       shutdown: state => function () {

--- a/bundles/ranvier-websocket/server-events/wss.js
+++ b/bundles/ranvier-websocket/server-events/wss.js
@@ -32,6 +32,7 @@ module.exports = srcPath => {
           // @see: bundles/ranvier-events/events/login.js
           stream.emit('intro', stream);
         });
+        Logger.log(`Websocket server started on port: ${wss.options.port}...`);
       },
 
       shutdown: state => function () {


### PR DESCRIPTION
Updated log message looks like this now:
```
2017-09-22T02:45:07.784Z - info: START - Starting server  
2017-09-22T02:45:07.784Z - info: Server started on port: 4000...  
2017-09-22T02:47:00.119Z - info: Websocket server started on port: 4001...
```