### PR TITLE
Moved critical hit logic from Core to Combat Bundle

### DIFF
--- a/bundles/ranvier-combat/lib/Combat.js
+++ b/bundles/ranvier-combat/lib/Combat.js
@@ -92,14 +92,14 @@ class Combat {
    * @param {Character} target
    */
   static makeAttack(attacker, target) {
-    //defines variables associated with critical strikes based on a random percentage chance.
+    // defines variables associated with critical strikes based on a random percentage chance.
     const critChance = Math.max(attacker.getMaxAttribute('critical') || 0, 0);
     const critical = Random.probability(critChance);
     const critMultiplier = critical ? 1.5 : 1;
     const amount = Math.ceil(this.calculateWeaponDamage(attacker) * critMultiplier);
     const damage = new Damage({ attribute: 'health', amount, attacker });
     
-    //implements critical strike if rolled successfully
+    // implements critical strike if rolled successfully
     if (critical) {
       damage.critical = true;
     }

--- a/bundles/ranvier-combat/lib/Combat.js
+++ b/bundles/ranvier-combat/lib/Combat.js
@@ -92,28 +92,26 @@ class Combat {
    * @param {Character} target
    */
   static makeAttack(attacker, target) {
-    const amount = this.calculateWeaponDamage(attacker);
-
-	//defines variables associated with critical strikes based on a random percentage chance.
+    //defines variables associated with critical strikes based on a random percentage chance.
     const critChance = Math.max(attacker.getMaxAttribute('critical') || 0, 0);
-    const critMultiplier = 1.5;
     const critical = Random.probability(critChance);
+    const critMultiplier = critical ? 1.5 : 1;
+    const amount = Math.ceil(this.calculateWeaponDamage(attacker) * critMultiplier);
     const damage = new Damage({ attribute: 'health', amount, attacker });
-	//implements critical strike if rolled successfully
+    
+    //implements critical strike if rolled successfully
     if (critical) {
-    	damage.amount = Math.ceil(amount * critMultiplier);
-    	damage.critical = true;
+      damage.critical = true;
     }
     damage.commit(target);
-
+  
     if (target.getAttribute('health') <= 0) {
       target.combatData.killedBy = attacker;
     }
-
-    // currently lag is really simple, the character's weapon speed = lag
+  
+      // currently lag is really simple, the character's weapon speed = lag
     attacker.combatData.lag = this.getWeaponSpeed(attacker) * 1000;
   }
-
   /**
    * Any cleanup that has to be done if the character is killed
    * @param {Character} deadEntity

--- a/bundles/ranvier-combat/lib/Combat.js
+++ b/bundles/ranvier-combat/lib/Combat.js
@@ -92,14 +92,13 @@ class Combat {
    * @param {Character} target
    */
   static makeAttack(attacker, target) {
-    var amount = this.calculateWeaponDamage(attacker);
+    const amount = this.calculateWeaponDamage(attacker);
 
 	//defines variables associated with critical strikes based on a random percentage chance.
     const critChance = Math.max(attacker.getMaxAttribute('critical') || 0, 0);
     const critMultiplier = 1.5;
     const critical = Random.probability(critChance);
-    
-	const damage = new Damage({ attribute: 'health', amount, attacker });
+    const damage = new Damage({ attribute: 'health', amount, attacker });
 	//implements critical strike if rolled successfully
     if (critical) {
     	damage.amount = Math.ceil(amount * critMultiplier);

--- a/bundles/ranvier-combat/lib/Combat.js
+++ b/bundles/ranvier-combat/lib/Combat.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Random = require('../../../src/RandomUtil')
 const Damage = require('../../../src/Damage');
 const Logger = require('../../../src/Logger');
 const RandomUtil = require('../../../src/RandomUtil');
@@ -91,8 +92,19 @@ class Combat {
    * @param {Character} target
    */
   static makeAttack(attacker, target) {
-    const amount = this.calculateWeaponDamage(attacker);
-    const damage = new Damage({ attribute: 'health', amount, attacker });
+    var amount = this.calculateWeaponDamage(attacker);
+
+	//defines variables associated with critical strikes based on a random percentage chance.
+    const critChance = Math.max(attacker.getMaxAttribute('critical') || 0, 0);
+    const critMultiplier = 1.5;
+    const critical = Random.probability(critChance);
+    
+	const damage = new Damage({ attribute: 'health', amount, attacker });
+	//implements critical strike if rolled successfully
+    if (critical) {
+    	damage.amount = Math.ceil(amount * critMultiplier);
+    	damage.critical = true;
+    }
     damage.commit(target);
 
     if (target.getAttribute('health') <= 0) {

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -62,6 +62,7 @@ module.exports = (srcPath) => {
        * @param {Character} target
        */
       hit: state => function (damage, target) {
+
         if (damage.hidden) {
           return;
         }

--- a/data/motd
+++ b/data/motd
@@ -1,4 +1,4 @@
-<white>RanvierMUD Codebase - Version 1.1.0
+<white>RanvierMUD Codebase - Version 2.0.0
 Shawn Biddle - Sean O'Donohue
 
                          _

--- a/docs/extending/classes.md
+++ b/docs/extending/classes.md
@@ -59,6 +59,8 @@ bundles/my-bundle/
 ```javascript
 'use strict';
 
+const Combat = require('../../ranvier-combat/lib/Combat');
+
 /**
  * Basic warrior attack
  */
@@ -74,7 +76,7 @@ module.exports = (srcPath) => {
   const damagePercent = 250;
   const energyCost = 20;
   
-  //This function calculates the damage.
+  //An example damage calculation using the Combat library from the ranvier-combat bundle
   function getDamage(player) {
     return Combat.calculateWeaponDamage(player) * (damagePercent / 100);
   }

--- a/docs/extending/classes.md
+++ b/docs/extending/classes.md
@@ -73,6 +73,11 @@ module.exports = (srcPath) => {
   // change them if you need to.
   const damagePercent = 250;
   const energyCost = 20;
+  
+  //This function calculates the damage.
+  function getDamage(player) {
+    return Combat.calculateWeaponDamage(player) * (damagePercent / 100);
+  }
 
   return {
     // Friendly name of the skill, shown to the player on the skill list command.
@@ -139,7 +144,7 @@ module.exports = (srcPath) => {
         // we'll damage the health of the target
         attribute: 'health',
         // for 250% of the player's weapon damage
-        amount: player.calculateWeaponDamage() * (damagePercent / 100),
+        amount: getDamage(player),
         attacker: player,
         type: 'physical',
         // Setting damage 'source' property to 'this' will show the skill that caused the

--- a/docs/extending/classes.md
+++ b/docs/extending/classes.md
@@ -76,7 +76,7 @@ module.exports = (srcPath) => {
   const damagePercent = 250;
   const energyCost = 20;
   
-  //An example damage calculation using the Combat library from the ranvier-combat bundle
+  // An example damage calculation using the Combat library from the ranvier-combat bundle
   function getDamage(player) {
     return Combat.calculateWeaponDamage(player) * (damagePercent / 100);
   }

--- a/src/Damage.js
+++ b/src/Damage.js
@@ -28,8 +28,6 @@ class Damage {
       type = "physical",
       source = null,
       hidden = false,
-      critical = false,
-      criticalMultiplier = 1.5
     } = config;
 
     if (amount === null) {
@@ -46,8 +44,6 @@ class Damage {
     this.source = source;
     this.attacker = attacker;
     this.hidden = hidden;
-    this.critical = critical;
-    this.criticalMultiplier = criticalMultiplier;
   }
 
   /**
@@ -59,11 +55,6 @@ class Damage {
     let amount = this.amount;
 
     if (this.attacker) {
-      const critChance = Math.max(this.attacker.getMaxAttribute('critical') || 0, 0);
-      this.critical = Random.probability(critChance);
-      if (this.critical) {
-        amount = Math.ceil(amount * this.criticalMultiplier);
-      }
       amount = this.attacker.evaluateOutgoingDamage(this, amount);
     }
 


### PR DESCRIPTION
Issue #342 resolved by moving critical hit logic from src/Damage.js to bundle/ranvier-combat/lib/Combat.js

I tested it a few times on fresh installs before making the pull request. If you see any issues with it, please make sure to let me know. This uses most of the same functions and maintains the exact same end-user functionality of the combat and critical system as before the modification.