### PR TITLE
Fix typo in heal player event.

### DIFF
--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -242,7 +242,7 @@ module.exports = (srcPath) => {
             continue;
           }
 
-          let buf = `${attacker}${source} heals ${this.name} for <b><red>${heal.finalamount}</red></b>.`;
+          let buf = `${attacker}${source} heals ${this.name} for <b><red>${heal.finalAmount}</red></b>.`;
           B.sayAt(member, buf);
         }
       },


### PR DESCRIPTION
When healing a party member, this typo led to text such as "Hork's Mend healed Test for undefined." Fixing it shows the correct number of points healed.