### PR TITLE
 Fix scriptless behaviors

### DIFF
--- a/src/Item.js
+++ b/src/Item.js
@@ -264,7 +264,8 @@ class Item extends Metadatable(EventEmitter) {
     for (let [behaviorName, config] of this.behaviors) {
       let behavior = state.ItemBehaviorManager.get(behaviorName);
       if (!behavior) {
-        return;
+        Logger.warn(`No script found for item behavior ${behaviorName}`);
+        continue;
       }
 
       // behavior may be a boolean in which case it will be `behaviorName: true`

--- a/src/Npc.js
+++ b/src/Npc.js
@@ -104,7 +104,8 @@ class Npc extends Character {
     for (const [behaviorName, config] of this.behaviors) {
       let behavior = state.MobBehaviorManager.get(behaviorName);
       if (!behavior) {
-        return;
+        Logger.warn(`No script found for NPC behavior ${behaviorName}`);
+        continue;
       }
 
       // behavior may be a boolean in which case it will be `behaviorName: true`

--- a/src/Room.js
+++ b/src/Room.js
@@ -403,7 +403,8 @@ class Room extends Metadatable(EventEmitter) {
     for (let [behaviorName, config] of this.behaviors) {
       let behavior = state.RoomBehaviorManager.get(behaviorName);
       if (!behavior) {
-        return;
+        Logger.warn(`No script found for item behavior ${behaviorName}`);
+        continue;
       }
 
       // behavior may be a boolean in which case it will be `behaviorName: true`


### PR DESCRIPTION
At present, if an entity has a defined behavior without a defined script, we will return from the behavior attachment method. This means that behaviors defined afterwards are simply not attached, regardless of whether or not they have scripts. 

This fix means that we can both use behavior definitions as metadata (As seen in the room-commands implementation in base Ranvier), and prevent hard-to-track bugs caused by defined behaviors not being attached without warning).